### PR TITLE
Upgrade dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libtest-mimic"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
 
 description = """

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,5 +16,5 @@ readme = "README.md"
 
 
 [dependencies]
-structopt = "0.2"
-termcolor = "0.3"
+structopt = "0.3.2"
+termcolor = "1.0.5"

--- a/src/args.rs
+++ b/src/args.rs
@@ -28,14 +28,14 @@ use structopt;
 #[derive(StructOpt, Debug, Clone)]
 #[structopt(
     template = "USAGE: [FLAGS] [OPTIONS] [FILTER]\n\n{all-args}\n\n\n{after-help}",
-    raw(setting = "structopt::clap::AppSettings::DisableVersion"),
+    setting = structopt::clap::AppSettings::DisableVersion,
     after_help = "By default, all tests are run in parallel. This can be altered with the \n\
         --test-threads flag or the RUST_TEST_THREADS environment variable when running \n\
         tests (set it to 1).\n\
         \n\
         All tests have their standard output and standard error captured by default. \n\
         This can be overridden with the --nocapture flag or setting RUST_TEST_NOCAPTURE \n\
-        environment variable to a value other than \"0\". Logging is not captured by default.",
+        environment variable to a value other than \"0\". Logging is not captured by default."
 )]
 pub struct Arguments {
     // ============== FLAGS ===================================================
@@ -47,7 +47,7 @@ pub struct Arguments {
     #[structopt(
         long = "--test",
         conflicts_with = "bench",
-        help = "Run tests and not benchmarks",
+        help = "Run tests and not benchmarks"
     )]
     pub test: bool,
 
@@ -63,14 +63,14 @@ pub struct Arguments {
     /// printed directly.
     #[structopt(
         long = "--nocapture",
-        help = "don't capture stdout/stderr of each task, allow printing directly",
+        help = "don't capture stdout/stderr of each task, allow printing directly"
     )]
     pub nocapture: bool,
 
     /// If set, filters are matched exactly rather than by substring.
     #[structopt(
         long = "--exact",
-        help = "Exactly match filters rather than by substring",
+        help = "Exactly match filters rather than by substring"
     )]
     pub exact: bool,
 
@@ -83,10 +83,9 @@ pub struct Arguments {
         short = "q",
         long = "--quiet",
         conflicts_with = "format",
-        help = "Display one character per test instead of one line. Alias to --format=terse",
+        help = "Display one character per test instead of one line. Alias to --format=terse"
     )]
     pub quiet: bool,
-
 
     // ============== OPTIONS =================================================
     /// Number of threads used for parallel testing.
@@ -101,7 +100,7 @@ pub struct Arguments {
     #[structopt(
         long = "--logfile",
         value_name = "PATH",
-        help = "Write logs to the specified file instead of stdout",
+        help = "Write logs to the specified file instead of stdout"
     )]
     pub logfile: Option<String>,
 
@@ -110,42 +109,41 @@ pub struct Arguments {
     #[structopt(
         long = "--skip",
         value_name = "FILTER",
-        raw(number_of_values = "1"),
-        help = "Skip tests whose names contain FILTER (this flag can be used multiple times)",
+        number_of_values = 1,
+        help = "Skip tests whose names contain FILTER (this flag can be used multiple times)"
     )]
     pub skip: Vec<String>,
 
     /// Specifies whether or not to color the output.
     #[structopt(
         long = "--color",
-        raw(possible_values = r#"&["auto", "always", "never"]"#),
+        possible_values = &["auto", "always", "never"],
         value_name = "auto|always|never",
         help = "Configure coloring of output: \n\
-            - auto = colorize if stdout is a tty and tests are run on serially (default)\n\
-            - always = always colorize output\n\
-            - never = never colorize output\n",
+                - auto = colorize if stdout is a tty and tests are run on serially (default)\n\
+                - always = always colorize output\n\
+                - never = never colorize output\n"
     )]
     pub color: Option<ColorSetting>,
 
     /// Specifies the format of the output.
     #[structopt(
         long = "--format",
-        raw(possible_values = r#"&["pretty", "terse", "json"]"#),
+        possible_values = &["pretty", "terse", "json"],
         value_name = "pretty|terse|json",
         help = "Configure formatting of output: \n\
-            - pretty = Print verbose output\n\
-            - terse = Display one character per test\n\
-            - json = Output a json document\n",
+                - pretty = Print verbose output\n\
+                - terse = Display one character per test\n\
+                - json = Output a json document\n"
     )]
     pub format: Option<FormatSetting>,
-
 
     // ============== POSITIONAL VALUES =======================================
     /// Filter string. Only tests which contain this string are run.
     #[structopt(
         name = "FILTER",
         help = "The FILTER string is tested against the name of all tests, and only those tests \
-            whose names contain the filter are run.",
+                whose names contain the filter are run."
     )]
     pub filter_string: Option<String>,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -35,7 +35,7 @@ use structopt;
         \n\
         All tests have their standard output and standard error captured by default. \n\
         This can be overridden with the --nocapture flag or setting RUST_TEST_NOCAPTURE \n\
-        environment variable to a value other than \"0\". Logging is not captured by default."
+        environment variable to a value other than \"0\". Logging is not captured by default.",
 )]
 pub struct Arguments {
     // ============== FLAGS ===================================================
@@ -47,7 +47,7 @@ pub struct Arguments {
     #[structopt(
         long = "--test",
         conflicts_with = "bench",
-        help = "Run tests and not benchmarks"
+        help = "Run tests and not benchmarks",
     )]
     pub test: bool,
 
@@ -63,14 +63,14 @@ pub struct Arguments {
     /// printed directly.
     #[structopt(
         long = "--nocapture",
-        help = "don't capture stdout/stderr of each task, allow printing directly"
+        help = "don't capture stdout/stderr of each task, allow printing directly",
     )]
     pub nocapture: bool,
 
     /// If set, filters are matched exactly rather than by substring.
     #[structopt(
         long = "--exact",
-        help = "Exactly match filters rather than by substring"
+        help = "Exactly match filters rather than by substring",
     )]
     pub exact: bool,
 
@@ -83,7 +83,7 @@ pub struct Arguments {
         short = "q",
         long = "--quiet",
         conflicts_with = "format",
-        help = "Display one character per test instead of one line. Alias to --format=terse"
+        help = "Display one character per test instead of one line. Alias to --format=terse",
     )]
     pub quiet: bool,
 
@@ -91,7 +91,7 @@ pub struct Arguments {
     /// Number of threads used for parallel testing.
     #[structopt(
         long = "--test-threads",
-        help = "Number of threads used for running tests in parallel"
+        help = "Number of threads used for running tests in parallel",
     )]
     pub num_threads: Option<u32>,
 
@@ -100,7 +100,7 @@ pub struct Arguments {
     #[structopt(
         long = "--logfile",
         value_name = "PATH",
-        help = "Write logs to the specified file instead of stdout"
+        help = "Write logs to the specified file instead of stdout",
     )]
     pub logfile: Option<String>,
 
@@ -110,7 +110,7 @@ pub struct Arguments {
         long = "--skip",
         value_name = "FILTER",
         number_of_values = 1,
-        help = "Skip tests whose names contain FILTER (this flag can be used multiple times)"
+        help = "Skip tests whose names contain FILTER (this flag can be used multiple times)",
     )]
     pub skip: Vec<String>,
 
@@ -120,9 +120,9 @@ pub struct Arguments {
         possible_values = &["auto", "always", "never"],
         value_name = "auto|always|never",
         help = "Configure coloring of output: \n\
-                - auto = colorize if stdout is a tty and tests are run on serially (default)\n\
-                - always = always colorize output\n\
-                - never = never colorize output\n"
+            - auto = colorize if stdout is a tty and tests are run on serially (default)\n\
+            - always = always colorize output\n\
+            - never = never colorize output\n",
     )]
     pub color: Option<ColorSetting>,
 
@@ -132,9 +132,9 @@ pub struct Arguments {
         possible_values = &["pretty", "terse", "json"],
         value_name = "pretty|terse|json",
         help = "Configure formatting of output: \n\
-                - pretty = Print verbose output\n\
-                - terse = Display one character per test\n\
-                - json = Output a json document\n"
+            - pretty = Print verbose output\n\
+            - terse = Display one character per test\n\
+            - json = Output a json document\n",
     )]
     pub format: Option<FormatSetting>,
 
@@ -143,7 +143,7 @@ pub struct Arguments {
     #[structopt(
         name = "FILTER",
         help = "The FILTER string is tested against the name of all tests, and only those tests \
-                whose names contain the filter are run."
+                whose names contain the filter are run.",
     )]
     pub filter_string: Option<String>,
 }


### PR DESCRIPTION
Rationale: When using structopt 0.3 it is not possible to flatten `Arguments` from this library due to incompatible derived structopt version.