### PR TITLE
args: Add Arguments::from_iter

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -157,6 +157,16 @@ impl Arguments {
     pub fn from_args() -> Self {
         structopt::StructOpt::from_args()
     }
+
+    /// Like `from_args()`, but operates on an explicit iterator and not the global arguments.
+    pub fn from_iter<I>(iter: I) -> Self
+    where
+        Self: Sized,
+        I: IntoIterator,
+        I::Item: Into<std::ffi::OsString> + Clone,
+    {
+        structopt::StructOpt::from_iter(iter)
+    }
 }
 
 /// Possible values for the `--color` option.


### PR DESCRIPTION
I'm working on a test suite for https://github.com/ostreedev/ostree/
and I want to have both destructive tests and non-destructive
tests in the same binary.  I'm doing my own argument parsing for
the destructive tests and then want to use this crate for the non-destructive
ones.