### PR TITLE
Fix --list --ignored behavior

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -328,7 +328,7 @@ pub fn run_tests<D: 'static + Send + Sync>(
 
     // If `--list` is specified, just print the list and return.
     if args.list {
-        printer.print_list(&tests);
+        printer.print_list(&tests, args.ignored);
         return Conclusion {
             has_failed: false,
             num_filtered_out: 0,


### PR DESCRIPTION
I'm trying to get libtest-mimic to work well with [cargo-nextest](https://nexte.st/) -- see the documentation on [custom
test harnesses](https://nexte.st/book/custom-test-harnesses.html) and nextest-rs/nextest#38. I'd love to recommend libtest-mimic as a way to write custom test harnesses.

One of the requirements for nextest is the ability to detect ignored and
non-ignored tests during the list phase. libtest prints out just the
ignored tests if you run `--list --ignored`: make libtest-mimic do the
same.

In my testing, this appears to be the only issue blocking libtest-mimic
from working with nextest.