### PR TITLE
Fix for CVE-2022-23639

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 
 
 [dependencies]
-crossbeam-channel = "0.4.2"
+crossbeam-channel = "0.5.4"
 clap = { version = "3.1.8", features = ["derive"] }
 rayon = "1.3.0"
 termcolor = "1.0.5"


### PR DESCRIPTION
Update crossbeam-channel to use the latest version of crossbeam-utils that's not vulenrable