### PR TITLE
Run on main thread when thead count set to 1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -377,8 +377,8 @@ pub fn run_tests<D: 'static + Send + Sync>(
 
     // Execute all tests
     if args.num_threads == Some(1) {
-        for (test, outcome) in &run_tests_main_thread(args, &mut printer, tests, run_test) {
-            collect_completion_info(test, outcome, &mut conclusion, &mut failed_tests);
+        for (test, outcome) in run_tests_main_thread(args, &mut printer, tests, run_test) {
+            collect_completion_info(test, &outcome, &mut conclusion, &mut failed_tests);
         }
     } else {
         for event in run_tests_threaded(args, tests, run_test) {
@@ -388,7 +388,7 @@ pub fn run_tests<D: 'static + Send + Sync>(
                     printer.print_test(&test.name, &test.kind);
                 }
                 printer.print_single_outcome(&outcome);
-                collect_completion_info(&test, &outcome, &mut conclusion, &mut failed_tests);
+                collect_completion_info(test, &outcome, &mut conclusion, &mut failed_tests);
             }
         };
     }

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -218,14 +218,14 @@ impl Printer {
 
     /// Prints a list of failed tests with their messages. This is only called
     /// if there were any failures.
-    pub(crate) fn print_failures(&mut self, fails: &[(String, Option<String>)]) {
+    pub(crate) fn print_failures<D>(&mut self, fails: &[(Test<D>, Option<String>)]) {
         writeln!(self.out).unwrap();
         writeln!(self.out, "failures:").unwrap();
         writeln!(self.out).unwrap();
 
         // Print messages of all tests
-        for (name, msg) in fails {
-            writeln!(self.out, "---- {} ----", name).unwrap();
+        for (test, msg) in fails {
+            writeln!(self.out, "---- {} ----", test.name).unwrap();
             if let Some(msg) = msg {
                 writeln!(self.out, "{}", msg).unwrap();
             }
@@ -235,8 +235,8 @@ impl Printer {
         // Print summary list of failed tests
         writeln!(self.out).unwrap();
         writeln!(self.out, "failures:").unwrap();
-        for (name, _) in fails {
-            writeln!(self.out, "    {}", name).unwrap();
+        for (test, _) in fails {
+            writeln!(self.out, "    {}", test.name).unwrap();
         }
     }
 

--- a/src/printer.rs
+++ b/src/printer.rs
@@ -218,14 +218,14 @@ impl Printer {
 
     /// Prints a list of failed tests with their messages. This is only called
     /// if there were any failures.
-    pub(crate) fn print_failures<D>(&mut self, fails: &[(Test<D>, Option<String>)]) {
+    pub(crate) fn print_failures(&mut self, fails: &[(String, Option<String>)]) {
         writeln!(self.out).unwrap();
         writeln!(self.out, "failures:").unwrap();
         writeln!(self.out).unwrap();
 
         // Print messages of all tests
-        for (test, msg) in fails {
-            writeln!(self.out, "---- {} ----", test.name).unwrap();
+        for (name, msg) in fails {
+            writeln!(self.out, "---- {} ----", name).unwrap();
             if let Some(msg) = msg {
                 writeln!(self.out, "{}", msg).unwrap();
             }
@@ -235,8 +235,8 @@ impl Printer {
         // Print summary list of failed tests
         writeln!(self.out).unwrap();
         writeln!(self.out, "failures:").unwrap();
-        for (test, _) in fails {
-            writeln!(self.out, "    {}", test.name).unwrap();
+        for (name, _) in fails {
+            writeln!(self.out, "    {}", name).unwrap();
         }
     }
 


### PR DESCRIPTION
Hi 👋 Thanks for your work on this library! It's pretty awesome 🙌 

I've been working on a small project using https://github.com/pfouilloux/bracket-lib/tree/master/bracket-terminal and I'd really like to use this but I need to be able to run my UI tests on the main thread.

Would you consider this PR to run tests on the main thread when the thread count is set to 1?
Do you think this would be a suitable approach?

Happy to do a bit of refactoring as well if this change appeals as the `RunnerEvent::Started` wouldn't be used anymore 🙂

Kind regards 🙂 

Examples run with this code:
![image](https://user-images.githubusercontent.com/7494211/178460786-b7fc018c-30e7-4128-b6f4-b55118182373.png)
![image](https://user-images.githubusercontent.com/7494211/178461318-31329287-2da6-4305-a745-527379fd4ad7.png)
![image](https://user-images.githubusercontent.com/7494211/178461493-17556fb4-f828-4762-8e59-234175571489.png)
![image](https://user-images.githubusercontent.com/7494211/178461705-c16127cc-4664-45c3-b1f2-f03f8684df13.png)
![image](https://user-images.githubusercontent.com/7494211/178461834-a1c20c7b-d40b-4710-b5d2-456be8dc90ce.png)
 
