### PR TITLE
Restore --nocapture as a no-op argument

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -44,6 +44,10 @@ pub struct Arguments {
     #[clap(long = "--list", help = "List all tests and benchmarks")]
     pub list: bool,
 
+    /// No-op, ignored (libtest-mimic always runs in no-capture mode)
+    #[clap(long = "--nocapture", help = "No-op (libtest-mimic always runs in no-capture mode)")]
+    pub nocapture: bool,
+
     /// If set, filters are matched exactly rather than by substring.
     #[clap(
         long = "--exact",


### PR DESCRIPTION
Nextest's [custom test harness] support requires that tests be run with
`--nocapture`. Since libtest-mimic doesn't capture output anyway, just
accept `--nocapture` as a no-op.

I verified that with this change, libtest-mimic becomes compatible
with nextest again.

[custom test harness]: https://nexte.st/book/custom-test-harnesses.html