### PR TITLE
Add extra (currently no-op) args to support IntelliJ Rust

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -46,6 +46,10 @@ pub struct Arguments {
     #[arg(long = "nocapture", help = "No-op (libtest-mimic always runs in no-capture mode)")]
     pub nocapture: bool,
 
+    /// Enable nightly-only flags
+    #[arg(short = 'Z')]
+    pub unstable_flags: Option<UnstableFlags>,
+
     /// If set, filters are matched exactly rather than by substring.
     #[arg(
         long = "exact",
@@ -166,6 +170,13 @@ impl Default for ColorSetting {
     fn default() -> Self {
         ColorSetting::Auto
     }
+}
+
+/// Possible values for the `-Z` option
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum UnstableFlags {
+    /// Allow use of experimental features
+    UnstableOptions,
 }
 
 /// Possible values for the `--format` option.

--- a/src/args.rs
+++ b/src/args.rs
@@ -46,6 +46,10 @@ pub struct Arguments {
     #[arg(long = "nocapture", help = "No-op (libtest-mimic always runs in no-capture mode)")]
     pub nocapture: bool,
 
+    /// No-op, ignored (libtest-mimic doesn't support this)
+    #[arg(long = "show-output")]
+    pub show_output: bool,
+
     /// Enable nightly-only flags
     #[arg(short = 'Z')]
     pub unstable_flags: Option<UnstableFlags>,


### PR DESCRIPTION
This partially gets us to working in IntelliJ Rust - #25.

When we do JSON support we should gate it behind `-Z unstable-options` as the json format isn't stable yet. This matches the official libtest behaviour.