### PR TITLE
Include the kind of test while matching filters

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,7 +401,9 @@ impl Arguments {
                 // For exact matches, we want to match against either the test name (to maintain
                 // backwards compatibility with older versions of libtest-mimic), or the test kind
                 // (technically more correct with respect to matching against the output of --list.)
-                true if test_name == skip_filter || &test_name_with_kind == skip_filter => return true,
+                true if test_name == skip_filter || &test_name_with_kind == skip_filter => {
+                    return true
+                }
                 false if test_name_with_kind.contains(skip_filter) => return true,
                 _ => {}
             }

--- a/tests/mixed_bag.rs
+++ b/tests/mixed_bag.rs
@@ -249,8 +249,8 @@ fn list_with_filter() {
 
 #[test]
 fn list_with_filter_exact() {
+    // --exact matches the test name either with or without the kind.
     let (c, out) = common::do_run(args(["--list", "--exact", "[apple] fox"]), tests());
-    // Matches all tests that contain "a" in either the name or the kind.
     assert_log!(out, "
         [apple] fox: test
     ");
@@ -260,7 +260,46 @@ fn list_with_filter_exact() {
         num_failed: 0,
         num_ignored: 0,
         num_measured: 0,
-     });
+    });
+    let (c, out) = common::do_run(args(["--list", "--exact", "fly"]), tests());
+    assert_log!(out, "
+        [banana] fly: test
+    ");
+    assert_eq!(c, Conclusion {
+        num_filtered_out: 0,
+        num_passed: 0,
+        num_failed: 0,
+        num_ignored: 0,
+        num_measured: 0,
+    });
+
+    // --skip --exact can be used to exclude tests.
+    let (c, out) = common::do_run(args(["--list", "--exact", "--skip", "[apple] fox", "--skip", "fly"]), tests());
+    assert_log!(out, "
+        cat: test
+        dog: test
+        [apple] bunny: test
+        frog: test
+        owl: test
+        [banana] bear: test
+        red: bench
+        blue: bench
+        [kiwi] yellow: bench
+        [kiwi] green: bench
+        purple: bench
+        cyan: bench
+        [banana] orange: bench
+        [banana] pink: bench
+    ");
+    assert_eq!(c, Conclusion {
+        num_filtered_out: 0,
+        num_passed: 0,
+        num_failed: 0,
+        num_ignored: 0,
+        num_measured: 0,
+    });
+
+    // --skip --exact matches test names without the kind as well.
 }
 
 #[test]

--- a/tests/mixed_bag.rs
+++ b/tests/mixed_bag.rs
@@ -227,11 +227,32 @@ fn list_ignored() {
 #[test]
 fn list_with_filter() {
     let (c, out) = common::do_run(args(["--list", "a"]), tests());
+    // Matches all tests that contain "a" in either the name or the kind.
     assert_log!(out, "
         cat: test
+        [apple] fox: test
+        [apple] bunny: test
+        [banana] fly: test
         [banana] bear: test
         cyan: bench
         [banana] orange: bench
+        [banana] pink: bench
+    ");
+    assert_eq!(c, Conclusion {
+        num_filtered_out: 0,
+        num_passed: 0,
+        num_failed: 0,
+        num_ignored: 0,
+        num_measured: 0,
+     });
+}
+
+#[test]
+fn list_with_filter_exact() {
+    let (c, out) = common::do_run(args(["--list", "--exact", "[apple] fox"]), tests());
+    // Matches all tests that contain "a" in either the name or the kind.
+    assert_log!(out, "
+        [apple] fox: test
     ");
     assert_eq!(c, Conclusion {
         num_filtered_out: 0,

--- a/tests/mixed_bag.rs
+++ b/tests/mixed_bag.rs
@@ -274,7 +274,17 @@ fn list_with_filter_exact() {
     });
 
     // --skip --exact can be used to exclude tests.
-    let (c, out) = common::do_run(args(["--list", "--exact", "--skip", "[apple] fox", "--skip", "fly"]), tests());
+    let (c, out) = common::do_run(
+        args([
+            "--list",
+            "--exact",
+            "--skip",
+            "[apple] fox",
+            "--skip",
+            "fly",
+        ]),
+        tests(),
+    );
     assert_log!(out, "
         cat: test
         dog: test


### PR DESCRIPTION
Consider a trial with name "my_test" and kind "foo". The text that gets printed out with `--list --format terse` is:

```
[foo] my_test: test
```

With libtest, an invariant is that the part of the string before ": test" can be passed into "--exact" to run that test. However, that invariant is currently not upheld by libtest-mimic: it only matches against the name of the test and not the kind. This breaks nextest's ability to run these tests: https://github.com/nextest-rs/nextest/issues/836

Make it so that libtest-mimic also matches against the kind of test, not just its name.

I also took the liberty of running rustfmt (or really, my editor automatically ran it when I went in to edit the file.)