### PR TITLE
Spawn the specified number of threads on the ThreadPool

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,7 +457,10 @@ pub fn run(args: &Arguments, mut tests: Vec<Trial>) -> Conclusion {
         }
     } else {
         // Run test in thread pool.
-        let pool = ThreadPool::default();
+        let pool = match args.test_threads {
+            Some(num_tests) => ThreadPool::new(num_tests),
+            None => ThreadPool::default()
+        };
         let (sender, receiver) = mpsc::channel();
 
         let num_tests = tests.len();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,7 +458,7 @@ pub fn run(args: &Arguments, mut tests: Vec<Trial>) -> Conclusion {
     } else {
         // Run test in thread pool.
         let pool = match args.test_threads {
-            Some(num_tests) => ThreadPool::new(num_tests),
+            Some(num_threads) => ThreadPool::new(num_threads),
             None => ThreadPool::default()
         };
         let (sender, receiver) = mpsc::channel();


### PR DESCRIPTION
I noticed that the behavior for running tests concurrently when specifying `--test-threads` handled either running them sequentially when `1` was provided, or running the tests with a number of threads equal to the number of CPU cores on the system otherwise. 

This change now instantiates the ThreadPool with the number of threads specified in the arguments, while still spawning a thread per core if `None` is specified.