### PR TITLE
Provide a mechanism to skip tests at runtime

### DIFF
--- a/src/printer.rs
+++ b/src/printer.rs
@@ -158,6 +158,7 @@ impl Printer {
                         writeln!(self.out).unwrap();
                         return;
                     }
+                    Outcome::RuntimeIgnored => 'S',
                 };
 
                 self.out.set_color(&color_of_outcome(outcome)).unwrap();
@@ -184,6 +185,7 @@ impl Printer {
                             Outcome::Failed(_) => "failed",
                             Outcome::Ignored => "ignored",
                             Outcome::Measured(_) => unreachable!(),
+                            Outcome::RuntimeIgnored => "skipped",
                         },
                         match outcome {
                             Outcome::Failed(Failed { msg: Some(msg) }) => {
@@ -317,6 +319,7 @@ impl Printer {
             Outcome::Failed { .. } => "FAILED",
             Outcome::Ignored => "ignored",
             Outcome::Measured { .. } => "bench",
+            Outcome::RuntimeIgnored => "skipped",
         };
 
         self.out.set_color(&color_of_outcome(outcome)).unwrap();
@@ -354,6 +357,7 @@ fn color_of_outcome(outcome: &Outcome) -> ColorSpec {
         Outcome::Failed { .. } => Color::Red,
         Outcome::Ignored => Color::Yellow,
         Outcome::Measured { .. } => Color::Cyan,
+        Outcome::RuntimeIgnored => Color::Blue,
     };
     out.set_fg(Some(color));
     out

--- a/tests/all_passing.rs
+++ b/tests/all_passing.rs
@@ -153,5 +153,5 @@ fn terse_output() {
         num_ignored: 0,
         num_measured: 0,
     });
-    assert_reordered_log(out.as_str(), 3, &["..."], &conclusion_to_output(&c));
+    assert_reordered_log(out.as_str(), 3, &["..."], &conclusion_to_output(&c), false);
 }

--- a/tests/all_passing.rs
+++ b/tests/all_passing.rs
@@ -2,7 +2,7 @@ use common::{args, check};
 use libtest_mimic::{Trial, Conclusion};
 use pretty_assertions::assert_eq;
 
-use crate::common::do_run;
+use crate::common::{assert_reordered_log, conclusion_to_output, do_run};
 
 #[macro_use]
 mod common;
@@ -153,10 +153,5 @@ fn terse_output() {
         num_ignored: 0,
         num_measured: 0,
     });
-    assert_log!(out, "
-        running 3 tests
-        ...
-        test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; \
-            finished in 0.00s
-    ");
+    assert_reordered_log(out.as_str(), 3, &["..."], &conclusion_to_output(&c));
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -135,8 +135,14 @@ pub fn check(
     assert_eq!(c, expected_conclusion);
 }
 
-fn conclusion_to_output(c: &Conclusion) -> String {
-    let Conclusion { num_filtered_out, num_passed, num_failed, num_ignored, num_measured } = *c;
+pub fn conclusion_to_output(c: &Conclusion) -> String {
+    let Conclusion {
+        num_filtered_out,
+        num_passed,
+        num_failed,
+        num_ignored,
+        num_measured,
+    } = *c;
     format!(
         "test result: {}. {} passed; {} failed; {} ignored; {} measured; {} filtered out;",
         if num_failed > 0 { "FAILED" } else { "ok" },


### PR DESCRIPTION
This closes #19 

It is useful to be able to _not_ pass or fail a test. Typically, this is accomplished by using the ignored flag; that works fine when the determination can be made before the `Trial` is pushed to the runner. There are cases where that information may not be known until the test is actually run.

In order to preserve API, a interface is created to allow created a test that may be skipped based on runtime information.

There is certainly room for discussion on how this is implemented. Using `Ok` was selected here as in my case it makes sense for a skipped test to be considered passing. For others, an enumerated `Failure` type might make more sense.