### PR TITLE
Switch from termcolor to anstream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "libtest-mimic"
 version = "0.7.3"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.65"
 
 description = """
 Write your own test harness that looks and behaves like the built-in test \
@@ -21,8 +21,9 @@ exclude = [".github"]
 [dependencies]
 clap = { version = "4.0.8", features = ["derive"] }
 threadpool = "1.8.1"
-termcolor = "1.0.5"
 escape8259 = "0.5.2"
+anstream = "0.6.14"
+anstyle = "1.0.7"
 
 [dev-dependencies]
 fastrand = "1.8.0"


### PR DESCRIPTION
Tested by running the `simple` example with various flags and environment variables, writing to a tty/pipe/file. I have not tested Windows console support but anstream explicitly supports both legacy wincon and the new ANSI capabilities, and I guess people are exercising that support via clap.

I also tested the new MSRV by running these commands (1.64 does not work):

```
rm Cargo.lock
CARGO_RESOLVER_SOMETHING_LIKE_PRECEDENCE=something-like-rust-version cargo +nightly -Zmsrv-policy check
cargo +1.65 test
```

Fix #42 