### PR TITLE
Avoid memory leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Replace dependency on threadpool crate with a custom solution built on the
+  standard library only, and only using scoped threads
+  -> fixes memory leaks observed when running under valgrind
+- up MSRV to 1.63 for scoped threads
 
 ## [0.7.3] - 2024-05-10
 - Default to single-threaded tests for WebAssembly (thanks @alexcrichton) in [#41](https://github.com/LukasKalbertodt/libtest-mimic/pull/41)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "libtest-mimic"
 version = "0.7.3"
 authors = ["Lukas Kalbertodt <lukas.kalbertodt@gmail.com>"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 description = """
 Write your own test harness that looks and behaves like the built-in test \
@@ -20,7 +20,6 @@ exclude = [".github"]
 
 [dependencies]
 clap = { version = "4.0.8", features = ["derive"] }
-threadpool = "1.8.1"
 termcolor = "1.0.5"
 escape8259 = "0.5.2"
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -1,0 +1,27 @@
+use std::{sync, thread};
+
+pub(crate) type Task = dyn FnOnce() + Send;
+pub(crate) type BoxedTask = Box<Task>;
+
+pub(crate) fn scoped_run_tasks(
+    tasks: Vec<BoxedTask>,
+    num_threads: usize,
+) {
+    if num_threads < 2 {
+        // There is another code path for num_threads == 1 running entirely in the main thread.
+        panic!("`run_on_scoped_pool` may not be called with `num_threads` less than 2");
+    }
+
+    let sync_iter = sync::Mutex::new(tasks.into_iter());
+    let next_task = || sync_iter.lock().unwrap().next();
+
+    thread::scope(|scope| {
+        for _ in 0..num_threads {
+            scope.spawn(|| {
+                while let Some(task) = next_task() {
+                    task();
+                }
+            });
+        }
+    });
+}


### PR DESCRIPTION
This commit replaces the `threadpool` crate with a handcrafted solution based on scoped threads. This leaves `valgrind` much happier than before. We also lose some dependency baggage.

Closes #45