### PR TITLE
Support panic backtraces, add log buffer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,7 +615,7 @@ pub fn log_additional_output(message: &str) {
         buf.push_str(message);
         if buf.len() > 20 * 1024 * 1024 {
             buf.clear();
-            buf.push_str("[truncated output]\n");
+            buf.push_str("\n[truncated output]");
         }
     });
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,13 @@
 #![forbid(unsafe_code)]
 
 use std::{
-    borrow::Cow, cell::RefCell, fmt, process::{self, ExitCode}, sync::{mpsc, Mutex, Once}, thread, time::Instant
+    borrow::Cow,
+    cell::RefCell,
+    fmt,
+    process::{self, ExitCode},
+    sync::{mpsc, Mutex, Once},
+    thread,
+    time::Instant,
 };
 
 mod args;

--- a/tests/panic.rs
+++ b/tests/panic.rs
@@ -31,6 +31,8 @@ fn normal() {
             ---- panics ----
             test panicked: uh oh
 
+            panic backtrace: did not capture, use RUST_BACKTRACE=1
+
 
             failures:
                 panics


### PR DESCRIPTION
When a test fails there is no way to use RUST_BACKTRACE=1 to show a
backtrace. This patch fixes the issue.

Additionally, it adds an explicit log buffer that can be used to work
around #9. That's a feature that the std harness doesn't have, but I
think it's appropriate to add since it's a workaround for something
libtest-mimic _doesn't_ but should have (stdout/err capturing)
