### PR TITLE
Provide a mechanism to skip tests at runtime

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -68,7 +68,9 @@ pub fn assert_reordered_log(actual: &str, num: u64, expected_lines: &[&str], tai
 
     for expected in expected_lines.iter().map(|l| l.trim()).filter(|l| !l.is_empty()) {
         match actual_lines.get_mut(expected) {
-            None | Some(0) => panic!("expected line \"{expected}\" not in log"),
+            None | Some(0) => {
+                panic!("expected line \"{expected}\" not in log. actual:\n```\n{actual}\n```")
+            }
             Some(num) => *num -= 1,
         }
     }


### PR DESCRIPTION
This is a revival of #38 (cc @bwidawsk) with the following changes:

- Change from an `Option<String>` to a custom enum
- Print the message in output, as is done by `libtest` when `#[ignore = "foo"]` is used
- Drop the commits adding log reordering and "sloppy" comparison

Fixes https://github.com/LukasKalbertodt/libtest-mimic/issues/19